### PR TITLE
(Fix): Downgrade camera packages 0.11.0 to 0.10.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  camera: ^0.11.0
+  #camera: ^0.11.0
+  camera: ^0.10.6
   google_mlkit_face_detection: ^0.11.0
 
 dev_dependencies:


### PR DESCRIPTION
Can not set default image format nv21 on Camera packages 0.11.0 so Plugin face camera will not working