### PR TITLE
Added a new parameter called ignoreFacePositioning in FaceCameraContr…

### DIFF
--- a/lib/src/controllers/face_camera_controller.dart
+++ b/lib/src/controllers/face_camera_controller.dart
@@ -19,6 +19,7 @@ class FaceCameraController extends ValueNotifier<FaceCameraState> {
     this.defaultFlashMode = CameraFlashMode.auto,
     this.enableAudio = true,
     this.autoCapture = false,
+    this.ignoreFacePositioning = false,
     this.orientation = CameraOrientation.portraitUp,
     this.performanceMode = FaceDetectorMode.fast,
     required this.onCapture,
@@ -39,6 +40,9 @@ class FaceCameraController extends ValueNotifier<FaceCameraState> {
 
   /// Set true to capture image on face detected.
   final bool autoCapture;
+
+  /// Set true to trigger onFaceDetected event if the face isn't well positioned
+  final bool ignoreFacePositioning;
 
   /// Use this to lock camera orientation.
   final CameraOrientation? orientation;
@@ -183,7 +187,7 @@ class FaceCameraController extends ValueNotifier<FaceCameraState> {
 
           if (result != null) {
             try {
-              if (result.wellPositioned) {
+              if (result.wellPositioned || ignoreFacePositioning) {
                 onFaceDetected?.call(result.face);
                 if (autoCapture) {
                   captureImage();


### PR DESCRIPTION
Added a new parameter called `ignoreFacePositioning` to `FaceCameraController`. This enables users to capture faces in the `onFaceDetected` callback (when face is detected) without the face being well positioned. This is useful when users just wish to capture the face and relay to another remote service, which will perform subsequent transformation operations. Default value is false, which will not cause any breaking changes to existing consumers of this package.